### PR TITLE
Issue #4: Fixed the pointer size to ensure proper memory access

### DIFF
--- a/source/WindowsAPICodePack/Core/PropertySystem/PropVariant.cs
+++ b/source/WindowsAPICodePack/Core/PropertySystem/PropVariant.cs
@@ -215,7 +215,7 @@ namespace MS.WindowsAPICodePack.Internal
         // the last 4-bytes of an 8-byte value on 32-bit
         // architectures.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
-        [FieldOffset(12)]
+        [FieldOffset(16)]
         IntPtr _ptr2;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         [FieldOffset(8)]


### PR DESCRIPTION
This change tries to resolve the issue #4: An AccessViolationException is sent by the PropVariant class
