### PR TITLE
Remove the border on the ExplorerBrowser control

### DIFF
--- a/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowser.cs
+++ b/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowser.cs
@@ -11,6 +11,7 @@ using MS.WindowsAPICodePack.Internal;
 using System.Text;
 using System.Linq;
 using Microsoft.WindowsAPICodePack.Shell.Interop;
+using Microsoft.WindowsAPICodePack.Shell.Interop.Common;
 
 namespace Microsoft.WindowsAPICodePack.Controls.WindowsForms
 {
@@ -316,6 +317,9 @@ namespace Microsoft.WindowsAPICodePack.Controls.WindowsForms
                 // This also enables the control panel to be browsed to. If it is not set, then navigating to 
                 // the control panel succeeds, but no items are visible in the view.
                 explorerBrowserControl.SetOptions(ExplorerBrowserOptions.ShowFrames);
+
+                // ExplorerBrowserOptions.NoBorder does not work, so we do it manually...
+                RemoveWindowBorder();
 
                 explorerBrowserControl.SetPropertyBag(propertyBagName);
 
@@ -844,6 +848,31 @@ namespace Microsoft.WindowsAPICodePack.Controls.WindowsForms
                 }
             }
             return iArray;
+        }
+
+        /// <summary>
+        /// Find the native control handle, remove its border style, then ask for a redraw.
+        /// </summary>
+        internal void RemoveWindowBorder()
+        {
+            // There is an option (EBO_NOBORDER) to avoid showing a border on the native ExplorerBrowser control
+            // so we wouldn't have to remove it afterwards, but:
+            // 1. It's not implemented by the Windows API Code Pack
+            // 2. The flag doesn't seem to work anyway (tested on 7 and 8.1)
+            // For reference: EXPLORER_BROWSER_OPTIONS https://msdn.microsoft.com/en-us/library/windows/desktop/bb762501(v=vs.85).aspx
+
+            IntPtr hwnd = WindowNativeMethods.FindWindowEx(Handle, IntPtr.Zero, "ExplorerBrowserControl", IntPtr.Zero);
+            int explorerBrowserStyle = WindowNativeMethods.GetWindowLong(hwnd, (int)WindowLongFlags.GWL_STYLE);
+            WindowNativeMethods.SetWindowLong(
+                hwnd,
+                (int)WindowLongFlags.GWL_STYLE,
+                explorerBrowserStyle & ~(int)WindowStyles.Caption & ~(int)WindowStyles.Border);
+            WindowNativeMethods.SetWindowPos(
+                hwnd,
+                IntPtr.Zero,
+                0, 0, 0, 0,
+                SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE);
+
         }
 
         #endregion

--- a/source/WindowsAPICodePack/Shell/Interop/Common/WindowNativeMethods.cs
+++ b/source/WindowsAPICodePack/Shell/Interop/Common/WindowNativeMethods.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.WindowsAPICodePack.Shell.Interop.Common
+{
+    internal static class WindowNativeMethods
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, IntPtr windowTitle);
+        /// <summary>
+        /// Changes an attribute of the specified window. The function also sets the 32-bit (long) value at the specified offset into the extra window memory.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window and, indirectly, the class to which the window belongs..</param>
+        /// <param name="nIndex">
+        /// The zero-based offset to the value to be set. Valid values are in the range zero through the number of bytes of extra window memory, minus the size of an integer.
+        /// To set any other value, specify one of the following values: GWL_EXSTYLE, GWL_HINSTANCE, GWL_ID, GWL_STYLE, GWL_USERDATA, GWL_WNDPROC.
+        /// </param>
+        /// <param name="dwNewLong">The replacement value.</param>
+        /// <returns>If the function succeeds, the return value is the previous value of the specified 32-bit integer.
+        /// If the function fails, the return value is zero. To get extended error information, call GetLastError. </returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int width, int height, SetWindowPosFlags flags);
+    }
+
+    internal enum WindowLongFlags
+    {
+        GWL_EXSTYLE = -20,
+        GWLP_HINSTANCE = -6,
+        GWLP_HWNDPARENT = -8,
+        GWL_ID = -12,
+        GWL_STYLE = -16,
+        GWL_USERDATA = -21,
+        GWL_WNDPROC = -4,
+        DWLP_USER = 0x8,
+        DWLP_MSGRESULT = 0x0,
+        DWLP_DLGPROC = 0x4
+    }
+
+    [Flags]
+    internal enum SetWindowPosFlags
+    {
+        SWP_NOSIZE = 0x0001,
+        SWP_NOMOVE = 0x0002,
+        SWP_NOZORDER = 0x0004,
+        SWP_NOREDRAW = 0x0008,
+        SWP_NOACTIVATE = 0x0010,
+        SWP_FRAMECHANGED = 0x0020,
+        SWP_SHOWWINDOW = 0x0040,
+        SWP_HIDEWINDOW = 0x0080,
+        SWP_NOCOPYBITS = 0x0100,
+        SWP_NOOWNERZORDER = 0x0200,
+        SWP_NOSENDCHANGING = 0x0400,
+        SWP_DRAWFRAME = 0x0020,
+        SWP_NOREPOSITION = 0x0200,
+        SWP_DEFERERASE = 0x2000,
+        SWP_ASYNCWINDOWPOS = 0x4000,
+    }
+}

--- a/source/WindowsAPICodePack/Shell/Interop/ExplorerBrowser/ExplorerBrowserCOMInterfaces.cs
+++ b/source/WindowsAPICodePack/Shell/Interop/ExplorerBrowser/ExplorerBrowserCOMInterfaces.cs
@@ -98,7 +98,9 @@ namespace Microsoft.WindowsAPICodePack.Controls
         AlwaysNavigate = 0x00000004,
         NoTravelLog = 0x00000008,
         NoWrapperWindow = 0x00000010,
-        HtmlSharepointView = 0x00000020
+        HtmlSharepointView = 0x00000020,
+        NoBorder = 0x00000040,
+        NoPersistViewState = 0x00000080,
     }
 
     internal enum CommDlgBrowserStateChange

--- a/source/WindowsAPICodePack/Shell/Shell.csproj
+++ b/source/WindowsAPICodePack/Shell/Shell.csproj
@@ -200,6 +200,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Interop\Common\IntPtrExtensions.cs" />
     <Compile Include="Interop\Common\ShellNativeStructs.cs" />
+    <Compile Include="Interop\Common\WindowNativeMethods.cs" />
     <Compile Include="Interop\ShellObjectWatcher\ShellObjectWatcherNativeMethods.cs" />
     <Compile Include="PropertySystem\PropertySystemException.cs" />
     <Compile Include="Interop\StockIcons\StockIconsNativeMethods.cs" />


### PR DESCRIPTION
There is an option (EBO_NOBORDER) to avoid showing a border on the native ExplorerBrowser control
but it wasn't implemented in the managed enum, and it doesn't seem to work when added...

So we have to do it manually by finding the control handle, and changing the window style.

With these changes, the ExplorerBrowser defaults to having no border whatsoever, the way it looks everywhere in Windows.
